### PR TITLE
Fix use plugin name as facade name

### DIFF
--- a/sirbot/core/core.py
+++ b/sirbot/core/core.py
@@ -127,7 +127,7 @@ class SirBot:
         if plugins:
             for plugin in plugins:
                 name = plugin.__name__
-                facade = getattr(plugin, '__facade__', name)
+                facade = plugin.__facade__ or plugin.__name__
                 config = self.config.get(name, {})
 
                 priority = config.get('priority', 50)

--- a/sirbot/core/plugin.py
+++ b/sirbot/core/plugin.py
@@ -14,10 +14,10 @@ class Plugin(ABC):  # pragma: no cover
     __version__ = '0.0.1'
     """Current version of the plugin"""
 
-    __name__ = 'test'
+    __name__ = 'plugin'
     """Name of the plugin"""
 
-    __facade__ = 'test'
+    __facade__ = ''
     """Name of the facade"""
 
     def __init__(self, loop):


### PR DESCRIPTION
When a plugin as no explicitly set facade name use the plugin name instead